### PR TITLE
Don't mark received messages as failed on receipt errors

### DIFF
--- a/lib/services/rustpush/rustpush_service.dart
+++ b/lib/services/rustpush/rustpush_service.dart
@@ -3558,8 +3558,14 @@ class RustPushService extends GetxService {
     if (myMsg.message is api.Message_Error) {
       var message = myMsg.message as api.Message_Error;
       var mistakeFor = Message.findOne(guid: message.field0.forUuid);
-      // if we've been delivered, well :shrug: probably some stray device complaining 
+      // if we've been delivered, well :shrug: probably some stray device complaining
       if (mistakeFor == null || mistakeFor.isDelivered) return; // multiple errors will likely come in, at which point guid will be bad.
+      // delivered/read receipts reuse the original message's UUID (see markCertified/markRead), so an error
+      // for a message we didn't author is a rejected receipt, not a send failure. Don't flag the received message.
+      if (mistakeFor.isFromMe != true) {
+        Logger.debug("Ignoring error ${message.field0.statusStr} for receipt on ${message.field0.forUuid}");
+        return;
+      }
       // do not flag 300 error messages for self handles
       var myHandles = (await api.getHandles(state: pushService.state!.client));
       if (!myHandles.contains(myMsg.sender)) return;


### PR DESCRIPTION
Delivered/read receipts are sent with the UUID of the message they acknowledge (see `markCertified` / `markRead`). When one of those receipts gets rejected, the resulting `Message_Error` is keyed to that same UUID, which is a message we *received*, not one we sent. The error handler then flagged the incoming message with a send failure.

This skips error handling for messages that aren't from us. Real send failures on our own messages are handled exactly as before.



Related: #206 and #61 are in this same handler but concern self-reflection errors on our own sends, which this does not change.
