### PR TITLE
Don't hide Find My / Shared Albums / Passwords in the menu before state loads

### DIFF
--- a/lib/app/layouts/conversation_list/widgets/header/header_widgets.dart
+++ b/lib/app/layouts/conversation_list/widgets/header/header_widgets.dart
@@ -173,7 +173,7 @@ class MaterialOverflowMenu extends StatelessWidget {
                 style: context.textTheme.bodyLarge!.apply(color: context.theme.colorScheme.properOnSurface),
               ),
             ),
-          if (pushService.state?.icloudServices?.sharedstreams != null)
+          if (backend.supportsSharedStreams())
             PopupMenuItem(
               value: 9,
               child: Text(
@@ -188,7 +188,7 @@ class MaterialOverflowMenu extends StatelessWidget {
                 style: context.textTheme.bodyLarge!.apply(color: context.theme.colorScheme.properOnSurface),
               ),
             ),
-          if (pushService.state?.icloudServices?.keychain != null)
+          if (backend.supportsKeychain())
           PopupMenuItem(
             value: 11,
             child: Text(
@@ -323,7 +323,7 @@ class CupertinoOverflowMenu extends StatelessWidget {
             icon: CupertinoIcons.location,
             onTap: () => goToFindMy(context),
           ),
-        if (pushService.state?.icloudServices?.sharedstreams != null)
+        if (backend.supportsSharedStreams())
           PullDownMenuItem(
             title: 'Shared Albums',
             icon: CupertinoIcons.photo,
@@ -334,7 +334,7 @@ class CupertinoOverflowMenu extends StatelessWidget {
           icon: CupertinoIcons.video_camera,
           onTap: () => goToFaceTime(context),
         ),
-        if (pushService.state?.icloudServices?.keychain != null)
+        if (backend.supportsKeychain())
         PullDownMenuItem(
           title: 'Passwords',
           icon: Icons.key,

--- a/lib/services/network/backend_service.dart
+++ b/lib/services/network/backend_service.dart
@@ -45,6 +45,8 @@ abstract class BackendService {
       {void Function(int, int)? onReceiveProgress, CancelToken? cancelToken});
   bool canSchedule();
   bool supportsFindMy();
+  bool supportsSharedStreams();
+  bool supportsKeychain();
   bool canCreateGroupChats();
   bool supportsSmsForwarding();
   void startedTyping(Chat c, [iMessageAppData? appdata]);

--- a/lib/services/network/http_service.dart
+++ b/lib/services/network/http_service.dart
@@ -277,6 +277,16 @@ class HttpBackend implements BackendService {
   }
 
   @override
+  bool supportsSharedStreams() {
+    return false;
+  }
+
+  @override
+  bool supportsKeychain() {
+    return false;
+  }
+
+  @override
   bool canCreateGroupChats() {
     return ss.canCreateGroupChatSync();
   }

--- a/lib/services/rustpush/rustpush_service.dart
+++ b/lib/services/rustpush/rustpush_service.dart
@@ -1265,7 +1265,17 @@ class RustPushBackend implements BackendService {
 
   @override
   bool supportsFindMy() {
-    return pushService.state?.icloudServices?.fmfd != null;
+    return pushService.hasFindMy;
+  }
+
+  @override
+  bool supportsSharedStreams() {
+    return pushService.hasSharedStreams;
+  }
+
+  @override
+  bool supportsKeychain() {
+    return pushService.hasKeychain;
   }
 
   @override
@@ -1307,7 +1317,45 @@ class RustPushBackend implements BackendService {
 }
 
 class RustPushService extends GetxService {
-  api.SharedPushState? state;
+  api.SharedPushState? _state;
+  api.SharedPushState? get state => _state;
+  set state(api.SharedPushState? value) {
+    _state = value;
+    _cacheCapabilities(value);
+  }
+
+  // Which iCloud services the account has is only known once the push state has
+  // loaded, which happens a few seconds after launch. Remember the last known
+  // answer so UI built before that (the overflow menu, for example) doesn't
+  // briefly hide Find My / Shared Streams / Passwords.
+  static const _capFindMy = "capFindMy";
+  static const _capSharedStreams = "capSharedStreams";
+  static const _capKeychain = "capKeychain";
+
+  void _cacheCapabilities(api.SharedPushState? value) {
+    if (value == null) {
+      ss.prefs.remove(_capFindMy);
+      ss.prefs.remove(_capSharedStreams);
+      ss.prefs.remove(_capKeychain);
+      return;
+    }
+    final services = value.icloudServices;
+    ss.prefs.setBool(_capFindMy, services?.fmfd != null);
+    ss.prefs.setBool(_capSharedStreams, services?.sharedstreams != null);
+    ss.prefs.setBool(_capKeychain, services?.keychain != null);
+  }
+
+  bool get hasFindMy => _state != null
+      ? _state!.icloudServices?.fmfd != null
+      : ss.prefs.getBool(_capFindMy) ?? false;
+
+  bool get hasSharedStreams => _state != null
+      ? _state!.icloudServices?.sharedstreams != null
+      : ss.prefs.getBool(_capSharedStreams) ?? false;
+
+  bool get hasKeychain => _state != null
+      ? _state!.icloudServices?.keychain != null
+      : ss.prefs.getBool(_capKeychain) ?? false;
 
   Mixpanel? mixpanel;
 


### PR DESCRIPTION
`pushService.state` takes a few seconds to load after launch. Both overflow menus (`MaterialOverflowMenu` and `CupertinoOverflowMenu`) gate the Find My, Shared Albums and Passwords entries on `pushService.state?.icloudServices?.*`, so if you open the menu during that window those entries are just missing, and the menu keeps rendering without them until it's closed and reopened.

Fix:
- `RustPushService.state` is now a property. Its setter records `fmfd` / `sharedstreams` / `keychain` availability to prefs whenever state is assigned (init, setup, re-registration), and removes those keys when state is set to null on logout so a cached answer can't outlive the account.
- New `hasFindMy` / `hasSharedStreams` / `hasKeychain` getters return the live answer when state is present and the cached one otherwise.
- `BackendService` gains `supportsSharedStreams()` and `supportsKeychain()` alongside the existing `supportsFindMy()`. The rustpush backend routes all three through the getters above; the HTTP backend returns false for the two new ones (it never had these features).
- Both menus call the backend methods instead of reading the push state directly.

Behavior is identical once state has loaded. The only visible change is that the first menu open after launch matches what you'd see a few seconds later.
